### PR TITLE
Viva es6

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,5 @@
 {
   "browserify": true,
-  "devel": true
+  "devel": true,
+  "esnext": true
 }
-

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var babelify = require('babelify');
 var browserify = require('browserify');
 var gulp = require('gulp');
 var gutil = require('gulp-util');
@@ -47,7 +48,7 @@ var buildBundle = function() {
 
 var bundle = watchify(browserify({
   entries: paths.ENTRY_POINTS,
-  transform: [reactify],
+  transform: [babelify, reactify],
   debug: true,
   cache: {},
   packageCache: {},

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "react": "^0.13.3"
   },
   "devDependencies": {
+    "babelify": "^6.3.0",
     "browserify": "^11.0.1",
     "gulp": "^3.9.0",
     "gulp-connect": "^2.2.0",

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,6 +1,4 @@
-'use strict';
-
-var React = require('react');
-var Container = require('./components/container');
+import React from 'react';
+import Container from './components/container';
 
 React.render(<Container />, document.getElementById('app'));

--- a/src/js/components/container.js
+++ b/src/js/components/container.js
@@ -1,12 +1,10 @@
-'use strict';
-
-var React = require('react');
-var classNames = require('classnames');
+import React from 'react';
+import classnames from 'classnames';
 
 
-var Container = React.createClass({
+export default React.createClass({
   render: function () {
-    var classes = classNames('container');
+    var classes = classnames('container');
 
     return (
       <div className={ classes }>
@@ -16,5 +14,3 @@ var Container = React.createClass({
     )
   }
 });
-
-module.exports = Container;


### PR DESCRIPTION
+ Add `babelify`, a babel browserify transform. This is to convert bundled javascript files written in ES6 back to ES5.
+ Convert javascript files into ES6 (thankfully there weren't a lot!)
+ Update `.jshintrc` to include the `esnext` property, which respects ES6 syntax.
