### PR TITLE
Add Grid Unit and Unit Section components, styles, specs

### DIFF
--- a/__tests__/grid-unit-test.js
+++ b/__tests__/grid-unit-test.js
@@ -1,0 +1,45 @@
+jest.autoMockOff();
+
+
+describe('Grid Unit', function () {
+  let GridUnit = require('../src/js/components/grid-unit.js');
+  let React = require('react/addons');
+  let TestUtils = React.addons.TestUtils;
+  let gridUnitView;
+
+  beforeEach(function () {
+    gridUnitView = TestUtils.renderIntoDocument(
+                    <GridUnit middleContent=''/>);
+  });
+
+  it('renders a left section', function () {
+    let leftSection = TestUtils.findRenderedDOMComponentWithClass(
+                        gridUnitView, 'grid-unit__left');
+    let leftSectionEl = React.findDOMNode(leftSection);
+    // Convert DOM Token List into array
+    let lClasses = Array.prototype.slice.call(leftSectionEl.classList, 0);
+
+    expect(leftSectionEl).toBeDefined();
+    expect(lClasses).toContain('grid-unit--sides');
+  });
+
+  it('renders a right section', function () {
+    let rightSection = TestUtils.findRenderedDOMComponentWithClass(
+                        gridUnitView, 'grid-unit__right');
+    let rightSectionEl = React.findDOMNode(rightSection);
+    let rClasses = Array.prototype.slice.call(rightSectionEl.classList, 0);
+
+    expect(rightSectionEl).toBeDefined();
+    expect(rClasses).toContain('grid-unit--sides');
+  });
+
+  it('renders a bottom (bot) section', function () {
+    let botSection = TestUtils.findRenderedDOMComponentWithClass(
+                        gridUnitView, 'grid-unit__bot');
+    let botSectionEl = React.findDOMNode(botSection);
+    let bClasses = Array.prototype.slice.call(botSectionEl.classList, 0);
+
+    expect(botSectionEl).toBeDefined();
+    expect(bClasses).not.toContain('grid-unit--sides');
+  });
+});

--- a/__tests__/grid-unit-test.js
+++ b/__tests__/grid-unit-test.js
@@ -1,18 +1,18 @@
 jest.autoMockOff();
 
 
-describe('Grid Unit', function () {
+describe('Grid Unit', () => {
   let GridUnit = require('../src/js/components/grid-unit.js');
   let React = require('react/addons');
   let TestUtils = React.addons.TestUtils;
   let gridUnitView;
 
-  beforeEach(function () {
+  beforeEach(() => {
     gridUnitView = TestUtils.renderIntoDocument(
                     <GridUnit middleContent=''/>);
   });
 
-  it('renders a left section', function () {
+  it('renders a left section', () => {
     let leftSection = TestUtils.findRenderedDOMComponentWithClass(
                         gridUnitView, 'grid-unit__left');
     let leftSectionEl = React.findDOMNode(leftSection);
@@ -23,7 +23,7 @@ describe('Grid Unit', function () {
     expect(lClasses).toContain('grid-unit--sides');
   });
 
-  it('renders a right section', function () {
+  it('renders a right section', () => {
     let rightSection = TestUtils.findRenderedDOMComponentWithClass(
                         gridUnitView, 'grid-unit__right');
     let rightSectionEl = React.findDOMNode(rightSection);
@@ -33,7 +33,7 @@ describe('Grid Unit', function () {
     expect(rClasses).toContain('grid-unit--sides');
   });
 
-  it('renders a bottom (bot) section', function () {
+  it('renders a bottom (bot) section', () => {
     let botSection = TestUtils.findRenderedDOMComponentWithClass(
                         gridUnitView, 'grid-unit__bot');
     let botSectionEl = React.findDOMNode(botSection);

--- a/__tests__/hero-test.js
+++ b/__tests__/hero-test.js
@@ -5,9 +5,11 @@ describe('Hero view', function () {
   let Hero = require('../src/js/components/hero.js');
   let React = require('react/addons');
   let TestUtils = React.addons.TestUtils;
-  let heroView;
+  let heroView, clickMock;
 
   beforeEach(function () {
+    clickMock = jest.genMockFunction();
+    Hero.prototype.handleClick = clickMock;
     heroView = TestUtils.renderIntoDocument(<Hero />);
   });
 
@@ -34,4 +36,11 @@ describe('Hero view', function () {
     expect(btnEl.className).toBe('hero__btn');
     expect(btnEl.innerHTML).toBe('Get to know me');
   });
+
+  it('calls handleClick() when the button is clicked', function () {
+    let btn = TestUtils.findRenderedDOMComponentWithTag(heroView, 'button');
+    TestUtils.Simulate.click(btn);
+
+    expect(clickMock).toBeCalled();
+  })
 });

--- a/__tests__/hero-test.js
+++ b/__tests__/hero-test.js
@@ -1,19 +1,19 @@
 jest.dontMock('../src/js/components/hero.js');
 
 
-describe('Hero view', function () {
+describe('Hero view', () => {
   let Hero = require('../src/js/components/hero.js');
   let React = require('react/addons');
   let TestUtils = React.addons.TestUtils;
   let heroView, clickMock;
 
-  beforeEach(function () {
+  beforeEach(() => {
     clickMock = jest.genMockFunction();
     Hero.prototype.handleClick = clickMock;
     heroView = TestUtils.renderIntoDocument(<Hero />);
   });
 
-  it('renders my name', function () {
+  it('renders my name', () => {
     let h1 = TestUtils.findRenderedDOMComponentWithTag(heroView, 'h1');
     let h1El = React.findDOMNode(h1);
 
@@ -21,7 +21,7 @@ describe('Hero view', function () {
     expect(h1El.innerHTML).toBe('Malcolm Ahoy');
   });
 
-  it('renders my title', function () {
+  it('renders my title', () => {
     let h2 = TestUtils.findRenderedDOMComponentWithTag(heroView, 'h2');
     let h2El = React.findDOMNode(h2);
 
@@ -29,7 +29,7 @@ describe('Hero view', function () {
     expect(h2El.innerHTML).toBe('Web Application Developer.');
   });
 
-  it('renders a button', function () {
+  it('renders a button', () => {
     let btn = TestUtils.findRenderedDOMComponentWithTag(heroView, 'button');
     let btnEl = React.findDOMNode(btn);
 
@@ -37,7 +37,7 @@ describe('Hero view', function () {
     expect(btnEl.innerHTML).toBe('Get to know me');
   });
 
-  it('calls handleClick() when the button is clicked', function () {
+  it('calls handleClick() when the button is clicked', () => {
     let btn = TestUtils.findRenderedDOMComponentWithTag(heroView, 'button');
     TestUtils.Simulate.click(btn);
 

--- a/__tests__/overview-test.js
+++ b/__tests__/overview-test.js
@@ -1,17 +1,17 @@
 jest.autoMockOff();
 
 
-describe('Overview', function () {
+describe('Overview', () => {
   let Overview = require('../src/js/components/content/overview');
   let React = require('react/addons');
   let TestUtils = React.addons.TestUtils;
   let overviewView;
 
-  beforeEach(function () {
+  beforeEach(() => {
     overviewView = TestUtils.renderIntoDocument(<Overview />);
   });
 
-  it('renders content into the middle unit section', function () {
+  it('renders content into the middle unit section', () => {
     let section = TestUtils.findRenderedDOMComponentWithClass(
                     overviewView, 'grid-unit__mid');
     let sectionEl = React.findDOMNode(section);
@@ -19,14 +19,14 @@ describe('Overview', function () {
     expect(sectionEl).toBeDefined();
   });
 
-  it('renders a grid unit Title', function () {
+  it('renders a grid unit Title', () => {
     let h1 = TestUtils.findRenderedDOMComponentWithTag(overviewView, 'h1');
     let h1El = React.findDOMNode(h1);
 
     expect(h1El.innerHTML).toBe('A Simple Overview');
   });
 
-  it('renders a quote of emphasis', function () {
+  it('renders a quote of emphasis', () => {
     let i = TestUtils.findRenderedDOMComponentWithTag(overviewView, 'i');
     let iEl = React.findDOMNode(i);
     let expectedQuote = '"It\'s harder to read code than to write it."';
@@ -34,7 +34,7 @@ describe('Overview', function () {
     expect(iEl.innerHTML).toBe(expectedQuote);
   });
 
-  it('renders four points total (title included)', function () {
+  it('renders four points total (title included)', () => {
     let lis = TestUtils.scryRenderedDOMComponentsWithTag(overviewView, 'li');
     // Convert list of components into array
     let lisArray = Array.prototype.slice.call(lis, 0);

--- a/__tests__/overview-test.js
+++ b/__tests__/overview-test.js
@@ -1,0 +1,44 @@
+jest.autoMockOff();
+
+
+describe('Overview', function () {
+  let Overview = require('../src/js/components/content/overview');
+  let React = require('react/addons');
+  let TestUtils = React.addons.TestUtils;
+  let overviewView;
+
+  beforeEach(function () {
+    overviewView = TestUtils.renderIntoDocument(<Overview />);
+  });
+
+  it('renders content into the middle unit section', function () {
+    let section = TestUtils.findRenderedDOMComponentWithClass(
+                    overviewView, 'grid-unit__mid');
+    let sectionEl = React.findDOMNode(section);
+
+    expect(sectionEl).toBeDefined();
+  });
+
+  it('renders a grid unit Title', function () {
+    let h1 = TestUtils.findRenderedDOMComponentWithTag(overviewView, 'h1');
+    let h1El = React.findDOMNode(h1);
+
+    expect(h1El.innerHTML).toBe('A Simple Overview');
+  });
+
+  it('renders a quote of emphasis', function () {
+    let i = TestUtils.findRenderedDOMComponentWithTag(overviewView, 'i');
+    let iEl = React.findDOMNode(i);
+    let expectedQuote = '"It\'s harder to read code than to write it."';
+
+    expect(iEl.innerHTML).toBe(expectedQuote);
+  });
+
+  it('renders four points total (title included)', function () {
+    let lis = TestUtils.scryRenderedDOMComponentsWithTag(overviewView, 'li');
+    // Convert list of components into array
+    let lisArray = Array.prototype.slice.call(lis, 0);
+
+    expect(lisArray.length).toBe(4);
+  });
+});

--- a/__tests__/unit-section-test.js
+++ b/__tests__/unit-section-test.js
@@ -1,0 +1,32 @@
+jest.autoMockOff();
+
+describe('Unit Section', function () {
+  let UnitSection = require('../src/js/components/unit-section.js');
+  let React = require('react/addons');
+  let TestUtils = React.addons.TestUtils;
+  let unitSectionView;
+
+  beforeEach(function () {
+    unitSectionView = TestUtils.renderIntoDocument(
+                        <UnitSection classNames='foobar'
+                                     symbol='barfoo' />);
+  });
+
+  it('renders a section (specified by its classnames)', function () {
+    let div = TestUtils.findRenderedDOMComponentWithTag(
+                unitSectionView, 'div');
+    let divEl = React.findDOMNode(div);
+
+    expect(divEl).toBeDefined();
+    expect(divEl.className).toBe('foobar');
+  });
+
+  it('renders a button to go to the next grid unit', function () {
+    let btn = TestUtils.findRenderedDOMComponentWithTag(
+                unitSectionView, 'button');
+    let btnEl = React.findDOMNode(btn);
+
+    expect(btnEl).toBeDefined();
+    expect(btnEl.innerHTML).toBe('barfoo');
+  });
+});

--- a/__tests__/unit-section-test.js
+++ b/__tests__/unit-section-test.js
@@ -1,18 +1,18 @@
 jest.autoMockOff();
 
-describe('Unit Section', function () {
+describe('Unit Section', () => {
   let UnitSection = require('../src/js/components/unit-section.js');
   let React = require('react/addons');
   let TestUtils = React.addons.TestUtils;
   let unitSectionView;
 
-  beforeEach(function () {
+  beforeEach(() => {
     unitSectionView = TestUtils.renderIntoDocument(
                         <UnitSection classNames='foobar'
                                      symbol='barfoo' />);
   });
 
-  it('renders a section (specified by its classnames)', function () {
+  it('renders a section (specified by its classnames)', () => {
     let div = TestUtils.findRenderedDOMComponentWithTag(
                 unitSectionView, 'div');
     let divEl = React.findDOMNode(div);
@@ -21,7 +21,7 @@ describe('Unit Section', function () {
     expect(divEl.className).toBe('foobar');
   });
 
-  it('renders a button to go to the next grid unit', function () {
+  it('renders a button to go to the next grid unit', () => {
     let btn = TestUtils.findRenderedDOMComponentWithTag(
                 unitSectionView, 'button');
     let btnEl = React.findDOMNode(btn);

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "My personal website and sandbox",
   "main": "index.js",
   "dependencies": {
+    "classnames": "^2.1.3",
+    "lodash.assign": "^3.2.0",
     "react": "^0.13.3",
     "react-router": "1.0.0-rc1"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "My personal website and sandbox",
   "main": "index.js",
   "dependencies": {
-    "react": "^0.13.3"
+    "react": "^0.13.3",
+    "react-router": "1.0.0-rc1"
   },
   "devDependencies": {
     "babel-jest": "*",
@@ -23,7 +24,9 @@
   },
   "jest": {
     "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",
-    "unmockedModulePathPatterns": ["<rootDir>/node_modules/react"]
+    "unmockedModulePathPatterns": [
+      "<rootDir>/node_modules/react"
+    ]
   },
   "scripts": {
     "test": "jest"

--- a/src/index.html
+++ b/src/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE HTML>
 <html>
   <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <link href='src/css/app.css' rel='stylesheet'>
   </head>
   <body>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import Hero from './components/hero';
+import startRouter from './router';
 
 
-React.render(<Hero />, document.getElementById('app'));
+startRouter(document.getElementById('app'));

--- a/src/js/components/content/overview.js
+++ b/src/js/components/content/overview.js
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import GridUnit from '../grid-unit';
+
+
+export default React.createClass({
+  getDefaultProps: function() {
+    return {
+      middleContent: (
+        <div className='grid-unit__mid'>
+          <ul>
+            <li>
+              <h1>A Simple Overview</h1>
+            </li>
+            <li>
+              I was a Web Application Engineer at Yola, Inc. from
+              June 2014 - August 2015. I mostly worked on the complex
+              client-side of their easy-to-use website making application.
+            </li>
+            <li>
+              A simple mantra I follow is to make my code as clean and simple
+              as possible. The most impactful advice I distinctly remember is:
+              <i>"It's harder to read code than to write it."</i>
+            </li>
+            <li>
+              I like learning. I like javascript. I'm a space enthusiast.
+              I like playing piano. I like basketball. I like video games.
+              I like burgers.
+            </li>
+          </ul>
+        </div>
+      )
+    };
+  },
+
+  render: GridUnit.prototype.render
+});

--- a/src/js/components/content/overview.js
+++ b/src/js/components/content/overview.js
@@ -3,35 +3,35 @@ import React from 'react';
 import GridUnit from '../grid-unit';
 
 
-export default React.createClass({
-  getDefaultProps: function() {
-    return {
-      middleContent: (
-        <div className='grid-unit__mid'>
-          <ul>
-            <li>
-              <h1>A Simple Overview</h1>
-            </li>
-            <li>
-              I was a Web Application Engineer at Yola, Inc. from
-              June 2014 - August 2015. I mostly worked on the complex
-              client-side of their easy-to-use website making application.
-            </li>
-            <li>
-              A simple mantra I follow is to make my code as clean and simple
-              as possible. The most impactful advice I distinctly remember is:
-              <i>"It's harder to read code than to write it."</i>
-            </li>
-            <li>
-              I like learning. I like javascript. I'm a space enthusiast.
-              I like playing piano. I like basketball. I like video games.
-              I like burgers.
-            </li>
-          </ul>
-        </div>
-      )
-    };
-  },
-
-  render: GridUnit.prototype.render
-});
+export default class Overview extends React.Component {
+  constructor() {
+    super();
+    this.render = GridUnit.prototype.render.bind(this);
+  };
+};
+Overview.defaultProps = {
+  middleContent: (
+    <div className='grid-unit__mid'>
+      <ul>
+        <li>
+          <h1>A Simple Overview</h1>
+        </li>
+        <li>
+          I was a Web Application Engineer at Yola, Inc. from
+          June 2014 - August 2015. I mostly worked on the complex
+          client-side of their easy-to-use website making application.
+        </li>
+        <li>
+          A simple mantra I follow is to make my code as clean and simple
+          as possible. The most impactful advice I distinctly remember is:
+          <i>"It's harder to read code than to write it."</i>
+        </li>
+        <li>
+          I like learning. I like javascript. I'm a space enthusiast.
+          I like playing piano. I like basketball. I like video games.
+          I like burgers.
+        </li>
+      </ul>
+    </div>
+  )
+};

--- a/src/js/components/grid-unit.js
+++ b/src/js/components/grid-unit.js
@@ -17,8 +17,8 @@ let bClasses = {
 };
 
 
-export default React.createClass({
-  render: function () {
+export default class GridUnit extends React.Component {
+  render() {
     let props = this.props;
     let leftUnitClasses = classNames(assign({}, lClasses, props.lClasses));
     let rightUnitClasses = classNames(assign({}, rClasses, props.rClasses));
@@ -31,6 +31,6 @@ export default React.createClass({
         <Section classNames={rightUnitClasses} symbol='&rarr;'/>
         <Section classNames={botUnitClasses} symbol='&darr;'/>
       </div>
-    )
-  }
-});
+    );
+  };
+};

--- a/src/js/components/grid-unit.js
+++ b/src/js/components/grid-unit.js
@@ -23,7 +23,6 @@ export default React.createClass({
     let leftUnitClasses = classNames(assign({}, lClasses, props.lClasses));
     let rightUnitClasses = classNames(assign({}, rClasses, props.rClasses));
     let botUnitClasses = classNames(assign({}, bClasses, props.bClasses));
-    console.log(props.middleContent);
 
     return (
       <div className='grid-unit'>

--- a/src/js/components/grid-unit.js
+++ b/src/js/components/grid-unit.js
@@ -1,0 +1,37 @@
+import assign from 'lodash.assign';
+import classNames from 'classnames';
+import React from 'react';
+
+import Section from './unit-section';
+
+let lClasses = {
+  'grid-unit__left': true,
+  'grid-unit--sides': true
+};
+let rClasses = {
+  'grid-unit__right': true,
+  'grid-unit--sides': true
+};
+let bClasses = {
+  'grid-unit__bot': true
+};
+
+
+export default React.createClass({
+  render: function () {
+    let props = this.props;
+    let leftUnitClasses = classNames(assign({}, lClasses, props.lClasses));
+    let rightUnitClasses = classNames(assign({}, rClasses, props.rClasses));
+    let botUnitClasses = classNames(assign({}, bClasses, props.bClasses));
+    console.log(props.middleContent);
+
+    return (
+      <div className='grid-unit'>
+        <Section classNames={leftUnitClasses} symbol='&larr;'/>
+        {props.middleContent}
+        <Section classNames={rightUnitClasses} symbol='&rarr;'/>
+        <Section classNames={botUnitClasses} symbol='&darr;'/>
+      </div>
+    )
+  }
+});

--- a/src/js/components/hero.js
+++ b/src/js/components/hero.js
@@ -1,16 +1,24 @@
 import React from 'react';
 
 
-export default React.createClass({
-  render: function () {
+export default class Hero extends React.Component {
+  handleClick(event) {
+    // can't use HTML5's pushState because react-router is hash based.
+    window.location.hash = 'overview';
+  };
+
+  render() {
     return (
       <div className='hero'>
         <div className='hero__mid'>
           <h1 className='hero__name'>Malcolm Ahoy</h1>
           <h2 className='hero__title'>Web Application Developer.</h2>
-          <button className='hero__btn'>Get to know me</button>
+          <button className='hero__btn'
+                  onClick={this.handleClick}>
+            Get to know me
+          </button>
         </div>
       </div>
     )
-  }
-});
+  };
+};

--- a/src/js/components/unit-section.js
+++ b/src/js/components/unit-section.js
@@ -1,12 +1,12 @@
 import React from 'react';
 
 
-export default React.createClass({
-  render: function () {
+export default class Section extends React.Component {
+  render() {
     return (
       <div className={this.props.classNames}>
         <button>{this.props.symbol}</button>
       </div>
-    )
-  }
-});
+    );
+  };
+};

--- a/src/js/components/unit-section.js
+++ b/src/js/components/unit-section.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+
+export default React.createClass({
+  render: function () {
+    return (
+      <div className={this.props.classNames}>
+        <button>{this.props.symbol}</button>
+      </div>
+    )
+  }
+});

--- a/src/js/router.js
+++ b/src/js/router.js
@@ -2,12 +2,14 @@ import React from 'react';
 import { Router, Route, Link } from 'react-router';
 
 import Hero from './components/hero';
+import Overview from './components/content/overview';
 
 
 export default function (DOMelement) {
   React.render((
     <Router>
       <Route path='/' component={Hero}/>
+      <Route path='overview' component={Overview}/>
       <Route path='*' component={Hero}/>
     </Router>
   ), DOMelement);

--- a/src/js/router.js
+++ b/src/js/router.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Router, Route, Link } from 'react-router';
+
+import Hero from './components/hero';
+
+
+export default function (DOMelement) {
+  React.render((
+    <Router>
+      <Route path='/' component={Hero}/>
+      <Route path='*' component={Hero}/>
+    </Router>
+  ), DOMelement);
+}

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -1,6 +1,8 @@
 $app-font-family: 'Open Sans', sans-serif;
 
 @import url(https://fonts.googleapis.com/css?family=Open+Sans);
+@import 'base-properties';
+@import 'grid-unit';
 @import 'hero';
 
 
@@ -9,7 +11,7 @@ $app-font-family: 'Open Sans', sans-serif;
 }
 
 // override default webkit margin
-body, h1, h2 {
+body, h1, h2, p {
   margin: 0;
 }
 

--- a/src/sass/grid-unit.scss
+++ b/src/sass/grid-unit.scss
@@ -1,0 +1,56 @@
+.grid-unit {
+  @extend .flex-container;
+  background-color: #EFD75B;
+  width: 100vw;
+  height: 100vh;
+
+  ul {
+    list-style: none;
+  }
+
+  li {
+    margin: 2em 0;
+    text-align: left;
+
+    i {
+      margin-left: 1em;
+    }
+  }
+
+  button {
+    border: none;
+    padding: 0.75em;
+  }
+
+  &--sides {
+    @extend .flex-container;
+    flex-basis: 10vw;
+    flex-grow: 1;
+    height: 90vh;
+  }
+
+  &__left {
+    order: 1;
+  }
+
+  &__right {
+    order: 3;
+  }
+
+  &__mid {
+    @extend .flex-container;
+    flex: 15 0px;
+    flex-basis: 80vw;
+    height: 90vh;
+    padding: 2em;
+    order: 2;
+  }
+
+  &__bot {
+    @extend .flex-container;
+    align-self: flex-end;
+    flex-basis: 100vw;
+    height: 10vh;
+    order: 4;
+  }
+}

--- a/src/sass/hero.scss
+++ b/src/sass/hero.scss
@@ -1,6 +1,3 @@
-@import 'base-properties';
-
-
 .hero {
   @extend .flex-container;
   background: url('../assets/img/golden-gate.jpg') no-repeat center center fixed;


### PR DESCRIPTION
The site is going to be setup in a fashion where users will traverse through a type of "grid". Each grid unit will have four unit sections:

1. Left section for navigating to the grid unit on the left
1. Mid section which contains the grid unit's main content
1. Right section for navigating to the grid unit on the right
1. Bot section for navigating to the grid unit on the bottom

A top section was purposely left out due to future plans of the website design.

+ Add a Overview grid unit, the very first one the user will see after navigating away from the hero page,
+ Add react router. Though the router generator module could easily instantiate the view
on its own, I prefer explicitly declaring which DOM Element it should
attach to.
+ Convert React components to ES6 syntax. Convert `function() { }`s to arrow functions.
+ Add `charset=utf-8` `<meta>` tag